### PR TITLE
Address using file name from untrusted source.

### DIFF
--- a/src/main/java/com/drajer/routing/impl/DirectResponseReceiver.java
+++ b/src/main/java/com/drajer/routing/impl/DirectResponseReceiver.java
@@ -104,7 +104,7 @@ public class DirectResponseReceiver extends RRReceiver {
 
               if ((bodyPart.getFileName().contains(".xml")
                   || bodyPart.getFileName().contains(".XML"))) {
-                String filename = UUID.randomUUID() + "_" + bodyPart.getFileName();
+                String filename = UUID.randomUUID() + ".xml";
                 logger.info("Found XML Attachment");
 
                 try (InputStream stream = bodyPart.getInputStream()) {


### PR DESCRIPTION
Using the filename from the email is not considered safe as the sender can manipulate the path.