### PR TITLE
Fix for Issue 104: codeSystemNames not populating

### DIFF
--- a/src/main/java/com/drajer/cda/utils/CdaGeneratorConstants.java
+++ b/src/main/java/com/drajer/cda/utils/CdaGeneratorConstants.java
@@ -912,7 +912,7 @@ public class CdaGeneratorConstants {
    * @param oid
    * @return URI|Name
    */
-  private static Pair<String, String> getURI(String oid) {
+  public static Pair<String, String> getURI(String oid) {
     if (oidMap.containsKey(oid)) {
       return oidMap.get(oid);
     } else {

--- a/src/main/java/com/drajer/cda/utils/CdaGeneratorConstants.java
+++ b/src/main/java/com/drajer/cda/utils/CdaGeneratorConstants.java
@@ -899,7 +899,7 @@ public class CdaGeneratorConstants {
       prop.load(input);
       prop.forEach(
           (key, value) -> {
-            String name = StringUtils.substringAfterLast((String) value, "/");
+            String name = getSplitValueURL(value);
             oidMap.put((String) key, new Pair<>((String) value, name));
             uriMap.put((String) value, new Pair<>((String) key, name));
           });
@@ -912,7 +912,7 @@ public class CdaGeneratorConstants {
    * @param oid
    * @return URI|Name
    */
-  public static Pair<String, String> getURI(String oid) {
+  private static Pair<String, String> getURI(String oid) {
     if (oidMap.containsKey(oid)) {
       return oidMap.get(oid);
     } else {
@@ -962,5 +962,20 @@ public class CdaGeneratorConstants {
     } else {
       return "WP";
     }
+  }
+
+  private static String getSplitValueURL(Object theValue) {
+    String name = "";
+    try {
+      String[] values = ((String) theValue).trim().split("\\s*\\|\\s*");
+      if (values.length > 1) {
+        name = values[1];
+      } else {
+        name = StringUtils.substringAfterLast((String) theValue, "/");
+      }
+    } catch (Exception e) {
+      logger.error("Error while processing the OID/URI map value", e);
+    }
+    return name;
   }
 }

--- a/src/main/resources/oid-uri-mapping-r4.properties
+++ b/src/main/resources/oid-uri-mapping-r4.properties
@@ -1,24 +1,24 @@
-2.16.840.1.113883.6.1=http://loinc.org
-2.16.840.1.113883.6.96=http://snomed.info/sct
-2.16.840.1.113883.6.88=http://www.nlm.nih.gov/research/umls/rxnorm
-2.16.840.1.113883.6.69=http://hl7.org/fhir/sid/ndc
-2.16.840.1.113883.6.101=http://nucc.org/provider-taxonomy
+2.16.840.1.113883.6.1=http://loinc.org|LOINC
+2.16.840.1.113883.6.96=http://snomed.info/sct|SNOMED-CT
+2.16.840.1.113883.6.88=http://www.nlm.nih.gov/research/umls/rxnorm|RxNorm
+2.16.840.1.113883.6.69=http://hl7.org/fhir/sid/ndc|NDC
+2.16.840.1.113883.6.101=http://nucc.org/provider-taxonomy|NUCC Provider Taxonomy
 2.16.840.1.113883.11.11555=http://terminology.hl7.org/RoleClass
-2.16.840.1.113883.6.12=http://www.ama-assn.org/go/cpt
-2.16.840.1.113883.3.26.1.1=http://ncimeta.nci.nih.gov
-2.16.840.1.113883.12.292=http://hl7.org/fhir/sid/cvx
-2.16.840.1.113883.6.3=http://hl7.org/fhir/sid/icd-10
-2.16.840.1.113883.6.90=http://hl7.org/fhir/sid/icd-10-cm
-2.16.840.1.113883.6.42=http://hl7.org/fhir/sid/icd-9-cm
+2.16.840.1.113883.6.12=http://www.ama-assn.org/go/cpt|AMA-CPT
+2.16.840.1.113883.3.26.1.1=http://ncimeta.nci.nih.gov|NCI Metathesaurus
+2.16.840.1.113883.12.292=http://hl7.org/fhir/sid/cvx|CVX (Vaccine Administered)
+2.16.840.1.113883.6.3=http://hl7.org/fhir/sid/icd-10|ICD-10
+2.16.840.1.113883.6.90=http://hl7.org/fhir/sid/icd-10-cm|ICD-10-CM
+2.16.840.1.113883.6.42=http://hl7.org/fhir/sid/icd-9-cm|ICD-9-CM
 urn:ietf:bcp:47=urn:ietf:bcp:47
 
-2.16.840.1.114222.4.5.314=https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.114222.4.5.314
-2.16.840.1.114222.4.5.315=https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.114222.4.5.315
-1.0.3166.1=https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=1.0.3166.1
+2.16.840.1.114222.4.5.314=https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.114222.4.5.314|Occupation CDC Census 2010
+2.16.840.1.114222.4.5.315=https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=2.16.840.1.114222.4.5.315|Industry CDC Census 2010
+1.0.3166.1=https://phinvads.cdc.gov/vads/ViewCodeSystem.action?id=1.0.3166.1|Country (ISO 3166-1)
 
-2.16.840.1.113883.4.6=http://hl7.org/fhir/sid/us-npi
-2.16.840.1.113883.4.1=http://hl7.org/fhir/sid/us-ssn
-2.16.840.1.113883.4.642.3.414=http://terminology.hl7.org/CodeSystem/organization-type
+2.16.840.1.113883.4.6=http://hl7.org/fhir/sid/us-npi|US-NPI
+2.16.840.1.113883.4.1=http://hl7.org/fhir/sid/us-ssn|US-SSN
+2.16.840.1.113883.4.642.3.414=http://terminology.hl7.org/CodeSystem/organization-type|OrganizationType
 
 2.16.840.1.113883.4.642.4.1246=http://terminology.hl7.org/CodeSystem/ActionType
 2.16.840.1.113883.4.642.4.1243=http://terminology.hl7.org/CodeSystem/ActivityDefinitionCategory
@@ -387,5 +387,5 @@ urn:ietf:bcp:47=urn:ietf:bcp:47
 2.16.840.1.113883.6.259=http://terminology.hl7.org/CodeSystem/v3-hsloc
 
 
-2.16.840.1.113883.6.277=http://hl7.org/fhir/us/hai/CodeSystem/2.16.840.1.113883.6.277
+2.16.840.1.113883.6.277=http://hl7.org/fhir/us/hai/CodeSystem/2.16.840.1.113883.6.277|CDC - National Healthcare Safety Network
 

--- a/src/test/java/com/drajer/cda/utils/CdaGeneratorConstantsTest.java
+++ b/src/test/java/com/drajer/cda/utils/CdaGeneratorConstantsTest.java
@@ -1,0 +1,34 @@
+package com.drajer.cda.utils;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.javatuples.Pair;
+import org.junit.Test;
+
+public class CdaGeneratorConstantsTest {
+
+  public String oid = "2.16.840.1.113883.6.96";
+  public String uri = "http://loinc.org|LOINC";
+
+  @Test
+  public void getURITest() {
+    Pair<String, String> uriValue = CdaGeneratorConstants.getURI(oid);
+    assertNotNull(uriValue);
+    assertEquals(uriValue.getValue(1), "SNOMED-CT");
+  }
+
+  @Test
+  public void getOIDTest() {
+    Pair<String, String> oidValue = CdaGeneratorConstants.getOID(uri);
+    assertNotNull(oidValue);
+    assertEquals(oidValue.getValue(1), "LOINC");
+  }
+
+  @Test
+  public void getCodeSystemFromUrlTest() {
+    Pair<String, String> uriValue = CdaGeneratorConstants.getCodeSystemFromUrl(uri);
+    assertNotNull(uriValue);
+    assertEquals(uriValue.getValue(1), "LOINC");
+  }
+}


### PR DESCRIPTION
Added a method to parse the properties file for the delimited value and return the name for the codeSystemNames.

Issue: https://github.com/drajer-health/eCRNow/issues/104