### PR TITLE
Initial Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM maven:3.8.1-adoptopenjdk-11 AS builder
+WORKDIR /build
+COPY pom.xml .
+RUN mvn dependency:resolve dependency:resolve-plugins
+
+COPY src src
+RUN mvn package -Dskip.unit.tests=true -Dskip.integration.tests=true
+
+FROM tomcat as appserver
+RUN sed -i 's/port="8080"/port="8081"/' ${CATALINA_HOME}/conf/server.xml
+EXPOSE 8081
+RUN mkdir /app-artifacts
+COPY documents/app-artifacts /app-artifacts
+
+RUN mkdir /schema
+COPY src/test/resources/AppData/Schema /schema
+
+VOLUME /config
+VOLUME /output
+VOLUME /logs
+
+RUN rm -fr /usr/local/tomcat/webapps/ROOT.war
+COPY --from=builder /build/target/ecr-now.war /usr/local/tomcat/webapps/ROOT.war


### PR DESCRIPTION
We found this Dockerfile handy when doing the disease surveillance work, which allowed us to run eCR Now on our containerized platform.

Usage:
```bash
docker build -t drajer-health/eCRNow .
docker run -p 8081:8081 drajer-health/eCRNow
```

You can optionally specify host directories for config, logs, and output. We took advantage of that and used it with docker-compose like so:

```yaml
version: "2.4"
services:
  ecr-now:
    image: drajer-health/eCRNow
    volumes:
      - ./services/ecr-now/config:/config
      - ./services/ecr-now/output:/output
      - ./services/ecr-now/logs:/logs
    environment:
      SPRING_CONFIG_LOCATION: 'file:///config/application.properties'
    ports:
      - "8081:8081"
```

In that example, the  `services/ecr-now/config` directory contains kars and an `application.properties` file which specified database authentication and the like.