### PR TITLE
Local app dev config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,6 @@
 				</exclusion>
 			</exclusions>
         </dependency>
-        
         <dependency>
 			<groupId>org.opencds.cqf.cql</groupId>
 			<artifactId>evaluator.measure-hapi</artifactId>
@@ -335,7 +334,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<scope>test</scope>
+			<!-- <scope>test</scope> -->
 		</dependency>
 		<dependency>
 			<groupId>com.github.tomakehurst</groupId>

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,0 +1,26 @@
+jdbc.driverClassName=org.h2.Driver
+jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+jdbc.username=sa
+jdbc.password=sa
+spring.test.database.replace=none
+hibernate.hbm2ddl.auto=create
+hibernate.dialect=org.hibernate.dialect.H2Dialect
+hibernate.show_sql=false
+hibernate.format_sql=false
+
+logging.file.name=target//output//logs//ecrNow.log
+ersd.file.location=src/test/resources/AppData/ersd_withonlycreateeicraction.json
+schematron.file.location=src/test/resources/AppData/CDAR2_IG_PHCASERPT_R2_STU1.1_SCHEMATRON.sch
+xsd.schemas.location=src/test/resources/AppData/Schema/infrastructure/cda/CDA_SDTC.xsd
+
+spring.h2.console.enabled=true
+
+authorization.service.impl.class=
+
+security.key=test123
+
+# Bsa Settings
+SofSystem=com.drajer.bsa.security.SystemLaunchAuthenticator
+kar.directory=documents//app-artifacts//kars
+bsa.output.directory=target//output//kars
+ignore.timers=true


### PR DESCRIPTION
This is a `dev` profile for eCR Now. It's a collection of changes that allow a developer to just start debugging the eCR Now application immediately without having to set up a database or configure kars, output, or log directories. The change are:

* Use H2 as the database
* Ignore timers
* Set the ersd, schematron, and xsd files to be those included in the test resources directory
* Set the output and log directories to be under the `target` directory. This means they get deleted and cleaned automatically when you run `mvn clean` and are ignored by default by git, so there's no chance of accidentally committing those files

You can use this profile by setting up your IDE to launch debug with the following environment variable set:
`SPRING_ACTIVE_PROFILE=local`

Both VSCode and IntelliJ support such configuration.