### PR TITLE
deduplicating resources

### DIFF
--- a/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
@@ -7,11 +7,13 @@ import com.drajer.bsa.ehr.service.EhrAuthorizationService;
 import com.drajer.bsa.ehr.service.EhrQueryService;
 import com.drajer.bsa.model.KarProcessingData;
 import com.drajer.sof.utils.FhirContextInitializer;
+import com.drajer.sof.utils.ResourceUtils;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.hl7.fhir.instance.model.api.IBaseBundle;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
@@ -197,13 +199,14 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
             logger.info(" Adding Resource Id : {}", comp.getResource().getId());
             resources.add(comp.getResource());
           }
-
-          resMap.put(resType, resources);
-          resMapById.put(id, resources);
+          Set<Resource> uniqueResources =
+              ResourceUtils.deduplicate(resources).stream().collect(Collectors.toSet());
+          resMap.put(resType, uniqueResources);
+          resMapById.put(id, uniqueResources);
           kd.addResourcesByType(resMap);
           kd.addResourcesById(resMapById);
 
-          logger.info(" Adding {} resources of type : {}", resources.size(), resType);
+          logger.info(" Adding {} resources of type : {}", uniqueResources.size(), resType);
         } else {
           logger.error(" No entries found for type : {}", resType);
         }

--- a/src/main/java/com/drajer/bsa/model/KarProcessingData.java
+++ b/src/main/java/com/drajer/bsa/model/KarProcessingData.java
@@ -7,10 +7,13 @@ import com.drajer.bsa.kar.model.KnowledgeArtifactStatus;
 import com.drajer.bsa.model.BsaTypes.ActionType;
 import com.drajer.bsa.scheduler.ScheduledJobData;
 import com.drajer.bsa.service.KarExecutionStateService;
+import com.drajer.sof.utils.ResourceUtils;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Resource;
@@ -182,9 +185,13 @@ public class KarProcessingData {
       logger.info(" Resource Sizes : {}", res.size());
       for (Map.Entry<ResourceType, Set<Resource>> entry : res.entrySet()) {
 
-        if (fhirInputDataByType.containsKey(entry.getKey()))
-          fhirInputDataByType.get(entry.getKey()).addAll(entry.getValue());
-        else fhirInputDataByType.put(entry.getKey(), entry.getValue());
+        if (fhirInputDataByType.containsKey(entry.getKey())) {
+          Set<Resource> resources = fhirInputDataByType.get(entry.getKey());
+          resources.addAll(entry.getValue());
+          Set<Resource> uniqueResources =
+              ResourceUtils.deduplicate(resources).stream().collect(Collectors.toSet());
+          fhirInputDataByType.put(entry.getKey(), uniqueResources);
+        } else fhirInputDataByType.put(entry.getKey(), entry.getValue());
       }
     }
   }
@@ -196,9 +203,13 @@ public class KarProcessingData {
       logger.info(" Resource Sizes : {}", res.size());
       for (Map.Entry<String, Set<Resource>> entry : res.entrySet()) {
 
-        if (fhirInputDataById.containsKey(entry.getKey()))
-          fhirInputDataById.get(entry.getKey()).addAll(entry.getValue());
-        else fhirInputDataById.put(entry.getKey(), entry.getValue());
+        if (fhirInputDataById.containsKey(entry.getKey())) {
+          Set<Resource> resources = fhirInputDataById.get(entry.getKey());
+          resources.addAll(entry.getValue());
+          Set<Resource> uniqueResources =
+              ResourceUtils.deduplicate(resources).stream().collect(Collectors.toSet());
+          fhirInputDataById.put(entry.getKey(), uniqueResources);
+        } else fhirInputDataById.put(entry.getKey(), entry.getValue());
       }
     }
   }
@@ -257,7 +268,9 @@ public class KarProcessingData {
 
         Set<Resource> res = entry.getValue();
 
-        for (Resource r : res) {
+        List<Resource> uniqueResources = ResourceUtils.deduplicate(res);
+
+        for (Resource r : uniqueResources) {
           bund.addEntry(new BundleEntryComponent().setResource(r));
         }
       }

--- a/src/main/java/com/drajer/sof/utils/ResourceUtils.java
+++ b/src/main/java/com/drajer/sof/utils/ResourceUtils.java
@@ -1,0 +1,40 @@
+package com.drajer.sof.utils;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+
+public class ResourceUtils {
+
+  public static <T extends IBaseResource> List<T> deduplicate(Collection<T> resources) {
+    Map<String, List<T>> groupedById =
+        resources
+            .stream()
+            .collect(
+                Collectors.groupingBy(
+                    x -> x.getIdElement().getResourceType() + "/" + x.getIdElement().getIdPart(),
+                    Collectors.toList()));
+
+    List<T> sorted =
+        groupedById
+            .entrySet()
+            .stream()
+            .map(
+                x ->
+                    x.getValue()
+                        .stream()
+                        .max(
+                            Comparator.comparingInt(
+                                y ->
+                                    y.getMeta() != null && y.getMeta().getVersionId() != null
+                                        ? Integer.parseInt(y.getMeta().getVersionId())
+                                        : 0))
+                        .get())
+            .collect(Collectors.toList());
+
+    return sorted;
+  }
+}


### PR DESCRIPTION
This PR runs some logic to deduplicate resources from Bundles.

NOTE: It assumes the meta.version is an int, which is true for our test resources, but not for all the resources in the Cerner sandbox! We need to discuss how to best resolve that.