### PR TITLE
Add support for fallback to "text" when "display" value is not presen…

### DIFF
--- a/src/main/java/com/drajer/cdafromr4/CdaImmunizationGenerator.java
+++ b/src/main/java/com/drajer/cdafromr4/CdaImmunizationGenerator.java
@@ -72,14 +72,10 @@ public class CdaImmunizationGenerator {
       // add Body Rows
       int rowNum = 1;
       for (Immunization imm : imms) {
-        String medDisplayName = CdaGeneratorConstants.UNKNOWN_VALUE;
 
-        if (imm.getVaccineCode() != null
-            && imm.getVaccineCode().getCodingFirstRep() != null
-            && !StringUtils.isEmpty(imm.getVaccineCode().getCodingFirstRep().getDisplay())) {
-
-          medDisplayName = imm.getVaccineCode().getCodingFirstRep().getDisplay();
-        }
+        String medDisplayName = CdaFhirUtilities.getStringForCodeableConcept(imm.getVaccineCode());
+        if (StringUtils.isEmpty(medDisplayName))
+          medDisplayName = CdaGeneratorConstants.UNKNOWN_VALUE;
 
         String dt = CdaGeneratorConstants.UNKNOWN_VALUE;
         if (imm.hasOccurrenceDateTimeType() && imm.getOccurrenceDateTimeType() != null) {

--- a/src/test/java/com/drajer/cdafromr4/CdaFhirUtilitiesTest.java
+++ b/src/test/java/com/drajer/cdafromr4/CdaFhirUtilitiesTest.java
@@ -2044,4 +2044,59 @@ public class CdaFhirUtilitiesTest extends BaseGeneratorTest {
       }
     }
   }
+
+  @Test
+  public void testGetStringForCodeableConcept_TextNotNull() {
+    CodeableConcept cd = new CodeableConcept();
+    cd.setText("Display-Text");
+    String result = CdaFhirUtilities.getStringForCodeableConcept(cd);
+    assertEquals("Display-Text", result);
+  }
+
+  @Test
+  public void testGetStringForCodeableConcept_TextNull() {
+    CodeableConcept cd = new CodeableConcept();
+
+    String result = CdaFhirUtilities.getStringForCodeableConcept(cd);
+    assertThat(result).isBlank();
+  }
+
+  @Test
+  public void testGetStringForCodeableConcept_TextNullAndCodingNotNull() {
+    CodeableConcept cd = new CodeableConcept();
+    Coding coding = new Coding();
+    coding.setSystem("http://loinc.org");
+    coding.setCode("15074-8");
+    coding.setDisplay("Glucose [Moles/volume] in Blood");
+
+    cd.addCoding(coding);
+    String result = CdaFhirUtilities.getStringForCodeableConcept(cd);
+    assertEquals("Glucose [Moles/volume] in Blood", result);
+  }
+
+  @Test
+  public void testGetStringForCodeableConcept_WithEmptyValue() {
+
+    assertThat(CdaFhirUtilities.getStringForCodeableConcept(null)).isBlank();
+  }
+
+  @Test
+  public void testGetStringForCodeableConcept_CodingListWithMultipleCodings() {
+    CodeableConcept cd = new CodeableConcept();
+    Coding coding1 = new Coding();
+    coding1.setSystem("http://loinc.org");
+    coding1.setCode("15074-8");
+    coding1.setDisplay("Glucose [Moles/volume] in Blood-1");
+
+    Coding coding2 = new Coding();
+    coding2.setSystem("http://loinc.org");
+    coding2.setCode("15074-8");
+    coding2.setDisplay("Glucose [Moles/volume] in Blood-2");
+
+    cd.addCoding(coding1);
+    cd.addCoding(coding2);
+
+    String result = CdaFhirUtilities.getStringForCodeableConcept(cd);
+    assertEquals("Glucose [Moles/volume] in Blood-1 | Glucose [Moles/volume] in Blood-2", result);
+  }
 }

--- a/src/test/java/com/drajer/cdafromr4/CdaImmunizationGeneratorTest.java
+++ b/src/test/java/com/drajer/cdafromr4/CdaImmunizationGeneratorTest.java
@@ -14,7 +14,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 @PrepareForTest({CdaGeneratorUtils.class})
 public class CdaImmunizationGeneratorTest extends BaseGeneratorTest {
 
-  private static final String IMMUNIZATION_FILE = "R4/Immunization/Immunization.json";
+  private static final String IMMUNIZATION_FILE = "CdaTestData/Immunization/Immunization.json";
   private static final String IMMUNIZATION_CDA_FILE =
       "CdaTestData/Cda/Immunization/Immunization.xml";
 

--- a/src/test/resources/CdaTestData/Cda/Immunization/Immunization.xml
+++ b/src/test/resources/CdaTestData/Cda/Immunization/Immunization.xml
@@ -23,7 +23,7 @@
 </tr>
 <tr>
 <td>
-<content ID="vaccine2">tetanus toxoid</content>
+<content ID="vaccine2">tetanus toxoid | tetanus toxoid, unspecified formulation</content>
 </td>
 <td>
 <content ID="vaccinationDate2">Sat Jan 01 00:00:00 UTC 2000</content>

--- a/src/test/resources/CdaTestData/Immunization/Immunization.json
+++ b/src/test/resources/CdaTestData/Immunization/Immunization.json
@@ -1,0 +1,202 @@
+{
+  "resourceType": "Bundle",
+  "id": "57ded0d8-408f-4872-b86f-8b9eccfa5fc4",
+  "type": "searchset",
+  "total": 3,
+  "link": [
+    {
+      "relation": "self",
+      "url": "https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Immunization?patient=12742571"
+    }
+  ],
+  "entry": [
+    {
+      "fullUrl": "https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Immunization/M197287364",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "M197287364",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2020-04-29T08:53:25-05:00"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Immunization</b></p><p><b>Vaccine</b>: zoster vaccine, inactivated</p><p><b>Occurrence</b>: 2014</p><p><b>Patient</b>: PORTER, MITCHELL D</p><p><b>Status</b>: Completed</p></div>"
+        },
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/72",
+              "code": "2556421249",
+              "display": "zoster vaccine, inactivated",
+              "userSelected": true
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "187",
+              "display": "zoster vaccine recombinant",
+              "userSelected": false
+            }
+          ],
+          "text": "zoster vaccine, inactivated"
+        },
+        "patient": {
+          "reference": "Patient/12742571",
+          "display": "FHIRTest, COVIDONE"
+        },
+        "encounter": {
+          "reference": "Encounter/97953900"
+        },
+        "occurrenceDateTime": "2014",
+        "primarySource": false,
+        "reportOrigin": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/30200",
+              "code": "19162977",
+              "display": "Spouse",
+              "userSelected": true
+            }
+          ],
+          "text": "Spouse"
+        },
+        "location": {
+          "reference": "Location/29598629",
+          "display": "ICU"
+        },
+        "doseQuantity":{
+          "value":1.25,
+          "unit":"mg",
+          "system":"http://unitsofmeasure.org",
+          "code":"mg"
+        }
+      }
+    },
+    {
+      "fullUrl": "https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Immunization/M197287360",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "M197287360",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2020-04-29T08:53:25-05:00"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Immunization</b></p><p><b>Vaccine</b>: tetanus toxoid</p><p><b>Occurrence</b>: 2000</p><p><b>Patient</b>: PORTER, MITCHELL D</p><p><b>Status</b>: Completed</p></div>"
+        },
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/72",
+              "code": "2798767",
+              "display": "tetanus toxoid",
+              "userSelected": true
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "112",
+              "display": "tetanus toxoid, unspecified formulation",
+              "userSelected": false
+            }
+          ]
+        },
+        "patient": {
+          "reference": "Patient/12742571",
+          "display": "FHIRTest, COVIDONE"
+        },
+        "encounter": {
+          "reference": "Encounter/97953900"
+        },
+        "occurrenceDateTime": "2000",
+        "primarySource": false,
+        "reportOrigin": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/30200",
+              "code": "19162977",
+              "display": "Spouse",
+              "userSelected": true
+            }
+          ],
+          "text": "Spouse"
+        },
+        "location": {
+          "reference": "Location/29598629",
+          "display": "ICU"
+        },
+        "doseQuantity": {
+          "value": 1.25,
+          "unit": "mg",
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        }
+      }
+    },
+    {
+      "fullUrl": "https://fhir-open.cerner.com/r4/ec2458f2-1e24-41c8-b71b-0e701af7583d/Immunization/M197287356",
+      "resource": {
+        "resourceType": "Immunization",
+        "id": "M197287356",
+        "meta": {
+          "versionId": "1",
+          "lastUpdated": "2020-04-29T08:53:25-05:00"
+        },
+        "text": {
+          "status": "generated",
+          "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Immunization</b></p><p><b>Vaccine</b>: influenza virus vaccine, live</p><p><b>Occurrence</b>: 2019</p><p><b>Patient</b>: PORTER, MITCHELL D</p><p><b>Status</b>: Completed</p></div>"
+        },
+        "status": "completed",
+        "vaccineCode": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/72",
+              "code": "2820756",
+              "display": "influenza virus vaccine, live",
+              "userSelected": true
+            },
+            {
+              "system": "http://hl7.org/fhir/sid/cvx",
+              "code": "111",
+              "display": "influenza virus vaccine, live, attenuated, for intranasal use",
+              "userSelected": false
+            }
+          ],
+          "text": "influenza virus vaccine, live"
+        },
+        "patient": {
+          "reference": "Patient/12742571",
+          "display": "FHIRTest, COVIDONE"
+        },
+        "encounter": {
+          "reference": "Encounter/97953900"
+        },
+        "occurrenceDateTime": "2019",
+        "primarySource": false,
+        "reportOrigin": {
+          "coding": [
+            {
+              "system": "https://fhir.cerner.com/ec2458f2-1e24-41c8-b71b-0e701af7583d/codeSet/30200",
+              "code": "19162977",
+              "display": "Spouse",
+              "userSelected": true
+            }
+          ],
+          "text": "Spouse"
+        },
+        "location": {
+          "reference": "Location/29598629",
+          "display": "ICU"
+        },
+        "doseQuantity": {
+          "value": 1.25,
+          "unit": "mg",
+          "system": "http://unitsofmeasure.org",
+          "code": "mg"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Changes Made:
- Updated the Immunizations class to check for the presence of the "display" value.
- If the "display" value is not present, the method now falls back to using the "text" value.
- Added for junits for testGetStringForCodeableConcept Method