### PR TITLE
Correct test fixture file path case sensitive error

### DIFF
--- a/src/test/java/com/drajer/cdafromr4/CdaImmunizationGeneratorTest.java
+++ b/src/test/java/com/drajer/cdafromr4/CdaImmunizationGeneratorTest.java
@@ -21,7 +21,7 @@ public class CdaImmunizationGeneratorTest extends BaseGeneratorTest {
   private static final String IMMUNIZATION_CDA_FILE =
       "CdaTestData/Cda/Immunization/Immunization.xml";
   private static final String IMMUNIZATION_WITH_PERFORMER_CDA_FILE =
-      "CdaTestData/Cda/Immunization/Immunization_with_performer.xml";
+      "CdaTestData/Cda/Immunization/immunization_with_performer.xml";
 
   @Test
   public void testGenerateImmunizationSection() {

--- a/src/test/java/com/drajer/cdafromr4/CdaPlanOfTreatmentGeneratorTest.java
+++ b/src/test/java/com/drajer/cdafromr4/CdaPlanOfTreatmentGeneratorTest.java
@@ -26,7 +26,7 @@ public class CdaPlanOfTreatmentGeneratorTest extends BaseGeneratorTest {
   static final String PLAN_OF_TREATMENT_BUNDLE_RESOURCE_FILE =
       "CdaTestData/PlanOfTreatment/plan_of_treatment_bundle_resource.json";
   static final String PLAN_OF_TREATMENT_CDA_FILE =
-      "CdaTestData//cda//PlanOfTreatment//PlanOfTreatment.xml";
+      "CdaTestData//Cda//PlanOfTreatment//PlanOfTreatment.xml";
 
   @Test
   public void testGeneratePlanOfTreatmentSection() {


### PR DESCRIPTION
fix: When attempting to build the app on an OS that has case-sensitive file paths (i.e. Debian Linux), these 2 tests fail. Opted to correct the file name reference in the test file rather than changing the fixture file name due to potential of accidental file duplication.