### PR TITLE
3.1.11 issues fixes

### DIFF
--- a/src/main/java/com/drajer/bsa/controller/PatientLaunchController.java
+++ b/src/main/java/com/drajer/bsa/controller/PatientLaunchController.java
@@ -470,7 +470,8 @@ public class PatientLaunchController {
     kd.getNotificationContext().setxRequestId(requestId);
     kd.setTokenRefreshThreshold(tokenRefreshThreshold);
     Resource res =
-        ehrService.getResourceById(kd, ResourceType.Encounter.toString(), context.getEncounterId());
+        ehrService.getResourceById(
+            kd, ResourceType.Encounter.toString(), context.getEncounterId(), true);
     nb.addEntry(new BundleEntryComponent().setResource(res));
 
     return nb;

--- a/src/main/java/com/drajer/bsa/ehr/service/EhrQueryService.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/EhrQueryService.java
@@ -53,7 +53,8 @@ public interface EhrQueryService {
 
   void deleteResource(KarProcessingData kd, ResourceType resourceType, String id);
 
-  Resource getResourceById(KarProcessingData data, String resourceName, String id);
+  Resource getResourceById(
+      KarProcessingData data, String resourceName, String id, boolean applyFiltering);
 
   Resource getResourceByUrl(KarProcessingData data, String resourceName, String id);
 

--- a/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
+++ b/src/main/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImpl.java
@@ -254,7 +254,7 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     // Get Patient by Id always
     Resource res =
         getResourceById(
-            client, context, PATIENT_RESOURCE, kd.getNotificationContext().getPatientId());
+            client, context, PATIENT_RESOURCE, kd.getNotificationContext().getPatientId(), true);
 
     if (res != null && res.getResourceType() != ResourceType.OperationOutcome) {
 
@@ -285,7 +285,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
               client,
               context,
               ResourceType.Encounter.toString(),
-              kd.getNotificationContext().getNotificationResourceId());
+              kd.getNotificationContext().getNotificationResourceId(),
+              true);
 
       if (enc != null && enc.getResourceType() != ResourceType.OperationOutcome) {
 
@@ -350,7 +351,7 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     // Get Patient by Id always
     Resource res =
         getResourceById(
-            client, context, PATIENT_RESOURCE, kd.getNotificationContext().getPatientId());
+            client, context, PATIENT_RESOURCE, kd.getNotificationContext().getPatientId(), true);
     if (res != null) {
 
       logger.info(
@@ -551,7 +552,11 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
               Practitioner practitioner =
                   (Practitioner)
                       getResourceById(
-                          client, context, ResourceType.Practitioner.toString(), practitionerID);
+                          client,
+                          context,
+                          ResourceType.Practitioner.toString(),
+                          practitionerID,
+                          true);
               if (practitioner != null && !practitionerMap.containsKey(practitionerID)) {
                 practitioners.add(practitioner);
                 kd.storeResourceById(practitionerID, practitioner);
@@ -575,7 +580,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
                       client,
                       context,
                       "Organization",
-                      organizationReference.getReferenceElement().getIdPart());
+                      organizationReference.getReferenceElement().getIdPart(),
+                      true);
           if (organization != null) {
             organizations.add(organization);
             kd.storeResourceById(
@@ -599,7 +605,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
                         client,
                         context,
                         "Location",
-                        locationReference.getReferenceElement().getIdPart());
+                        locationReference.getReferenceElement().getIdPart(),
+                        true);
             if (locationResource != null) {
               locations.add(locationResource);
               kd.storeResourceById(
@@ -700,7 +707,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
   }
 
   @Override
-  public Resource getResourceById(KarProcessingData kd, String resourceName, String resourceId) {
+  public Resource getResourceById(
+      KarProcessingData kd, String resourceName, String resourceId, boolean applyFiltering) {
 
     logger.info(LOG_FHIR_CTX_GET);
     FhirContext context = fhirContextInitializer.getFhirContext(R4);
@@ -708,11 +716,15 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     logger.info(LOG_INIT_FHIR_CLIENT);
     IGenericClient client = getClient(kd, context);
 
-    return getResourceById(client, context, resourceName, resourceId);
+    return getResourceById(client, context, resourceName, resourceId, applyFiltering);
   }
 
   public Resource getResourceById(
-      IGenericClient genericClient, FhirContext context, String resourceName, String resourceId) {
+      IGenericClient genericClient,
+      FhirContext context,
+      String resourceName,
+      String resourceId,
+      boolean applyFiltering) {
 
     Resource resource = null;
 
@@ -723,7 +735,7 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
       resource =
           (Resource) (genericClient.read().resource(resourceName).withId(resourceId).execute());
 
-      if (!isValidResource(resource)) resource = null;
+      if (applyFiltering && !isValidResource(resource)) resource = null;
 
     } catch (BaseServerResponseException responseException) {
       if (responseException.getOperationOutcome() != null) {
@@ -1326,7 +1338,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
                     genericClient,
                     context,
                     ResourceType.Medication.toString(),
-                    medRef.getReferenceElement().getIdPart());
+                    medRef.getReferenceElement().getIdPart(),
+                    true);
           }
 
           if (secRes != null && secRes.getResourceType() != ResourceType.OperationOutcome) {
@@ -1357,7 +1370,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
                     genericClient,
                     context,
                     ResourceType.Medication.toString(),
-                    medRef.getReferenceElement().getIdPart());
+                    medRef.getReferenceElement().getIdPart(),
+                    true);
           }
 
           if (secRes != null && secRes.getResourceType() != ResourceType.OperationOutcome) {
@@ -1369,7 +1383,34 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
             kd.storeResourceById(medRef.getReferenceElement().getIdPart(), secRes);
           }
         } // has Id Part in Reference
-      } // has MedicationReference
+      } else if (mAdm.hasRequest()) {
+        Reference medRequestRef = (Reference) mAdm.getRequest();
+
+        if (medRequestRef.getReferenceElement().hasIdPart()) {
+          Resource secRes =
+              kd.getResourceById(
+                  medRequestRef.getReferenceElement().getIdPart(), ResourceType.MedicationRequest);
+
+          if (secRes == null) {
+            secRes =
+                getResourceById(
+                    genericClient,
+                    context,
+                    ResourceType.MedicationRequest.toString(),
+                    medRequestRef.getReferenceElement().getIdPart(),
+                    false);
+          }
+
+          if (secRes != null && secRes.getResourceType() != ResourceType.OperationOutcome) {
+
+            logger.info(
+                " Adding secondary Medication Request resource for MedicationAdministration with id {}",
+                secRes.getId());
+            kd.addResourceByType(secRes.getResourceType(), secRes);
+            kd.storeResourceById(medRequestRef.getReferenceElement().getIdPart(), secRes);
+          }
+        }
+      }
     } else if (res != null && rType == ResourceType.MedicationStatement) {
 
       MedicationStatement mst = (MedicationStatement) res;
@@ -1388,7 +1429,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
                     genericClient,
                     context,
                     ResourceType.Medication.toString(),
-                    medRef.getReferenceElement().getIdPart());
+                    medRef.getReferenceElement().getIdPart(),
+                    true);
           }
 
           if (secRes != null && secRes.getResourceType() != ResourceType.OperationOutcome) {
@@ -1419,7 +1461,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
                     genericClient,
                     context,
                     ResourceType.Medication.toString(),
-                    medRef.getReferenceElement().getIdPart());
+                    medRef.getReferenceElement().getIdPart(),
+                    true);
           }
 
           if (secRes != null && secRes.getResourceType() != ResourceType.OperationOutcome) {
@@ -1509,7 +1552,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
                     genericClient,
                     context,
                     ResourceType.Observation.toString(),
-                    r.getReferenceElement().getIdPart());
+                    r.getReferenceElement().getIdPart(),
+                    true);
           }
 
           if (secRes != null
@@ -1567,7 +1611,7 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
     if (secRes == null) {
       secRes =
           getResourceById(
-              genericClient, context, type.toString(), ref.getReferenceElement().getIdPart());
+              genericClient, context, type.toString(), ref.getReferenceElement().getIdPart(), true);
     }
 
     addResourceToContext(kd, secRes, ref.getReferenceElement().getIdPart(), false);
@@ -1734,7 +1778,8 @@ public class EhrFhirR4QueryServiceImpl implements EhrQueryService {
       logger.debug(LOG_INIT_FHIR_CLIENT);
       IGenericClient client = getClient(data, context);
 
-      Resource res = getResourceById(client, context, ResourceType.Encounter.toString(), encId);
+      Resource res =
+          getResourceById(client, context, ResourceType.Encounter.toString(), encId, true);
 
       if (res != null) enc = (Encounter) res;
     }

--- a/src/main/java/com/drajer/bsa/service/impl/KarProcessorImpl.java
+++ b/src/main/java/com/drajer/bsa/service/impl/KarProcessorImpl.java
@@ -242,7 +242,7 @@ public class KarProcessorImpl implements KarProcessor {
                 kd.setContextEncounter(
                     (Encounter)
                         ehrInterface.getResourceById(
-                            kd, "Encounter", nc.getNotificationResourceId()));
+                            kd, "Encounter", nc.getNotificationResourceId(), true));
                 nc.setNotifiedResource(kd.getContextEncounter());
               }
 

--- a/src/main/java/com/drajer/cda/utils/CdaGeneratorUtils.java
+++ b/src/main/java/com/drajer/cda/utils/CdaGeneratorUtils.java
@@ -1214,39 +1214,70 @@ public class CdaGeneratorUtils {
   public static String getXmlForPIVLWithTS(String elName, String frequencyInHours) {
 
     String s = "";
-    s +=
-        CdaGeneratorConstants.START_XMLTAG
-            + elName
-            + CdaGeneratorConstants.SPACE
-            + CdaGeneratorConstants.XSI_TYPE
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.PIVL_TS_TYPE
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.SPACE
-            + "institutionSpecified="
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.CCDA_TRUE
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.SPACE
-            + "operator="
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.PIVL_TS_OPERATOR_VAL
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.RIGHT_ANGLE_BRACKET
-            + "\n"
-            + CdaGeneratorConstants.START_XMLTAG
-            + "period value="
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + frequencyInHours
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.SPACE
-            + CdaGeneratorConstants.UNIT_WITH_EQUAL
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.HOURS_UNITS_NAME
-            + CdaGeneratorConstants.DOUBLE_QUOTE
-            + CdaGeneratorConstants.END_XMLTAG_NEWLN
-            + CdaGeneratorUtils.getXmlForEndElement(elName);
-
+    if (StringUtils.isNotBlank(frequencyInHours)) {
+      s +=
+          CdaGeneratorConstants.START_XMLTAG
+              + elName
+              + CdaGeneratorConstants.SPACE
+              + CdaGeneratorConstants.XSI_TYPE
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.PIVL_TS_TYPE
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.SPACE
+              + "institutionSpecified="
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.CCDA_TRUE
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.SPACE
+              + "operator="
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.PIVL_TS_OPERATOR_VAL
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.RIGHT_ANGLE_BRACKET
+              + "\n"
+              + CdaGeneratorConstants.START_XMLTAG
+              + "period value="
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + frequencyInHours
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.SPACE
+              + CdaGeneratorConstants.UNIT_WITH_EQUAL
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.HOURS_UNITS_NAME
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.END_XMLTAG_NEWLN
+              + CdaGeneratorUtils.getXmlForEndElement(elName);
+    } else {
+      s +=
+          CdaGeneratorConstants.START_XMLTAG
+              + elName
+              + CdaGeneratorConstants.SPACE
+              + CdaGeneratorConstants.XSI_TYPE
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.PIVL_TS_TYPE
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.SPACE
+              + "institutionSpecified="
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.CCDA_TRUE
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.SPACE
+              + "operator="
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.PIVL_TS_OPERATOR_VAL
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.RIGHT_ANGLE_BRACKET
+              + "\n"
+              + CdaGeneratorConstants.START_XMLTAG
+              + "period"
+              + CdaGeneratorConstants.SPACE
+              + CdaGeneratorConstants.NULLFLAVOR_WITH_EQUAL
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + StringEscapeUtils.escapeXml10(CdaGeneratorConstants.NF_UNK)
+              + CdaGeneratorConstants.DOUBLE_QUOTE
+              + CdaGeneratorConstants.END_XMLTAG_NEWLN
+              + CdaGeneratorUtils.getXmlForEndElement(elName);
+    }
     return s;
   }
 

--- a/src/main/java/com/drajer/cdafromr4/CdaHeaderGenerator.java
+++ b/src/main/java/com/drajer/cdafromr4/CdaHeaderGenerator.java
@@ -5,11 +5,10 @@ import static com.drajer.cda.utils.CdaGeneratorConstants.FHIR_NPI_URL;
 import com.drajer.cda.utils.CdaGeneratorConstants;
 import com.drajer.cda.utils.CdaGeneratorUtils;
 import com.drajer.eca.model.ActionRepo;
+import com.drajer.ecrapp.config.AppConfig;
 import com.drajer.ecrapp.model.Eicr;
 import com.drajer.sof.model.LaunchDetails;
 import com.drajer.sof.model.R4FhirData;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,21 +57,7 @@ public class CdaHeaderGenerator {
   }
 
   public static void loadProperties() {
-    String propertiesFileName = getPropertiesFileName();
-
-    try (InputStream input =
-        CdaHeaderGenerator.class.getClassLoader().getResourceAsStream(propertiesFileName)) {
-      if (input != null) {
-        Properties properties = new Properties();
-        properties.load(input);
-        appProps.putAll((Map) properties);
-
-      } else {
-        logger.error("Properties file {} not found in classpath!", propertiesFileName);
-      }
-    } catch (IOException e) {
-      logger.error("Error loading properties file :{} ", e);
-    }
+    appProps = (HashMap<String, String>) AppConfig.getAllProperties();
   }
 
   private static String getPropertiesFileName() {
@@ -561,7 +546,7 @@ public class CdaHeaderGenerator {
       sb.append(
           CdaGeneratorUtils.getXmlForText(
               CdaGeneratorConstants.NAME_EL_NAME, data.getOrganization().getName()));
-
+      sb.append(CdaFhirUtilities.getTelecomXml(org.getTelecom(), false, false));
       sb.append(CdaFhirUtilities.getAddressXml(data.getOrganization().getAddress(), false));
 
       sb.append(CdaGeneratorUtils.getXmlForEndElement(CdaGeneratorConstants.REP_ORG_EL_NAME));
@@ -977,9 +962,10 @@ public class CdaHeaderGenerator {
     // Adding Guardian
     if (p.getContact() != null && !p.getContact().isEmpty()) {
 
-      ContactComponent guardianContact = CdaFhirUtilities.getGuardianContact(p.getContact());
+      List<ContactComponent> guardianContacts =
+          CdaFhirUtilities.getGuardianContacts(p.getContact());
 
-      if (guardianContact != null) {
+      for (ContactComponent guardianContact : guardianContacts) {
 
         patientDetails.append(
             CdaGeneratorUtils.getXmlForStartElement(CdaGeneratorConstants.GUARDIAN_EL_NAME));

--- a/src/main/java/com/drajer/cdafromr4/CdaMedicationGenerator.java
+++ b/src/main/java/com/drajer/cdafromr4/CdaMedicationGenerator.java
@@ -94,6 +94,8 @@ public class CdaMedicationGenerator {
         Quantity dose = null;
 
         String periodText = CdaGeneratorConstants.UNKNOWN_VALUE;
+        String period;
+        String periodUnit;
         if (med.hasDosage()) {
           dosageValue = med.getDosageFirstRep();
 
@@ -102,8 +104,8 @@ public class CdaMedicationGenerator {
             if (t != null && t.hasRepeat()) {
 
               Timing.TimingRepeatComponent repeat = t.getRepeat();
-              String period = repeat.hasPeriod() ? repeat.getPeriod().toString() : null;
-              String periodUnit = repeat.hasPeriodUnit() ? repeat.getPeriodUnit().toString() : null;
+              period = repeat.hasPeriod() ? repeat.getPeriod().toString() : null;
+              periodUnit = repeat.hasPeriodUnit() ? repeat.getPeriodUnit().toString() : null;
               String frequency =
                   repeat.hasFrequency() ? String.valueOf(repeat.getFrequency()) : null;
               periodText = CdaFhirUtilities.getNarrative(frequency, period, periodUnit);
@@ -436,6 +438,9 @@ public class CdaMedicationGenerator {
       sb.append(
           CdaGeneratorUtils.getXmlForPIVLWithTS(
               CdaGeneratorConstants.EFF_TIME_EL_NAME, freqInHours));
+    } else {
+      sb.append(
+          CdaGeneratorUtils.getXmlForPIVLWithTS(CdaGeneratorConstants.EFF_TIME_EL_NAME, null));
     }
 
     // Add Route Code
@@ -1339,10 +1344,13 @@ public class CdaMedicationGenerator {
         }
 
         Quantity dose = null;
+
         if (medAdm.hasDosage()
             && medAdm.getDosage() != null
             && medAdm.getDosage().hasDose()
-            && medAdm.getDosage().getDose() != null) dose = medAdm.getDosage().getDose();
+            && medAdm.getDosage().getDose() != null) {
+          dose = medAdm.getDosage().getDose();
+        }
 
         medEntries.append(
             getEntryForMedication(
@@ -1350,7 +1358,7 @@ public class CdaMedicationGenerator {
                 medAdm.getMedication(),
                 medAdm.getEffective(),
                 medstatus,
-                null,
+                convertToDosage(medAdm.getDosage()),
                 details,
                 dose,
                 null,
@@ -1708,5 +1716,24 @@ public class CdaMedicationGenerator {
     }
 
     return retVal;
+  }
+
+  public static Dosage convertToDosage(
+      MedicationAdministration.MedicationAdministrationDosageComponent adminDosage) {
+    if (adminDosage == null) {
+      return null;
+    }
+
+    Dosage dosage = new Dosage();
+
+    if (adminDosage.hasText()) {
+      dosage.setText(adminDosage.getText());
+    }
+
+    if (adminDosage.hasRoute()) {
+      dosage.setRoute(adminDosage.getRoute().copy());
+    }
+
+    return dosage;
   }
 }

--- a/src/main/java/com/drajer/ecrapp/config/AppConfig.java
+++ b/src/main/java/com/drajer/ecrapp/config/AppConfig.java
@@ -1,13 +1,24 @@
 package com.drajer.ecrapp.config;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AppConfig {
 
+  @Autowired Environment environment;
+
   @Value("${longencounter.enableSuspend:false}")
   private boolean enableSuspend;
+
+  private static Map<String, String> props = new HashMap<>();
 
   @Value("${longencounter.suspendThreshold:45}")
   private int suspendThreshold;
@@ -26,5 +37,35 @@ public class AppConfig {
 
   public void setSuspendThreshold(final int suspendThreshold) {
     this.suspendThreshold = suspendThreshold;
+  }
+
+  public Environment getEnvironment() {
+    return environment;
+  }
+
+  @PostConstruct
+  public Map<String, String> readAllProperties() {
+
+    if (environment instanceof ConfigurableEnvironment) {
+      ConfigurableEnvironment configEnv = (ConfigurableEnvironment) environment;
+
+      for (PropertySource<?> propertySource : configEnv.getPropertySources()) {
+        if (propertySource.getSource() instanceof Map) {
+          @SuppressWarnings("unchecked")
+          Map<String, Object> source = (Map<String, Object>) propertySource.getSource();
+          for (Map.Entry<String, Object> entry : source.entrySet()) {
+            if (!props.containsKey(entry.getKey())) {
+              props.put(entry.getKey(), String.valueOf(entry.getValue()));
+            }
+          }
+        }
+      }
+    }
+
+    return props;
+  }
+
+  public static Map<String, String> getAllProperties() {
+    return props;
   }
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <include resource="org/springframework/boot/logging/logback/defaults.xml" />
-    <property name="LOG_FILE" value="${LOG_FILE:-${LOG_PATH:-${LOG_TEMP:-${java.io.tmpdir:-/tmp}}/}spring.log}"/>
-    <include resource="org/springframework/boot/logging/logback/file-appender.xml" />
-    <root level="INFO">
-        <appender-ref ref="FILE" />
-    </root>
-</configuration> 

--- a/src/test/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImplTest.java
+++ b/src/test/java/com/drajer/bsa/ehr/service/impl/EhrFhirR4QueryServiceImplTest.java
@@ -74,7 +74,7 @@ public class EhrFhirR4QueryServiceImplTest {
     Patient mockPatient = new Patient();
     mockPatient.setId("123");
     Mockito.lenient()
-        .when(ehrFhirR4QueryService.getResourceById(any(), any(), eq("Patient"), eq("123")))
+        .when(ehrFhirR4QueryService.getResourceById(any(), any(), eq("Patient"), eq("123"), true))
         .thenReturn(mockPatient);
 
     Map<String, ResourceType> resTypes = new HashMap<>();
@@ -86,6 +86,6 @@ public class EhrFhirR4QueryServiceImplTest {
     assertNotNull(result);
     assertTrue(result.containsKey(ResourceType.Patient));
     assertEquals(1, result.get(ResourceType.Patient).size());
-    verify(ehrFhirR4QueryService).getResourceById(any(), any(), eq("Patient"), eq("123"));
+    verify(ehrFhirR4QueryService).getResourceById(any(), any(), eq("Patient"), eq("123"), true);
   }
 }

--- a/src/test/java/com/drajer/cdafromr4/CdaFhirUtilitiesTest.java
+++ b/src/test/java/com/drajer/cdafromr4/CdaFhirUtilitiesTest.java
@@ -395,8 +395,8 @@ public class CdaFhirUtilitiesTest extends BaseGeneratorTest {
     relationship.addCoding(coding);
     guardianContact.setRelationship(Collections.singletonList(relationship));
     contacts.add(guardianContact);
-    ContactComponent result = CdaFhirUtilities.getGuardianContact(contacts);
-    assertEquals(guardianContact, result);
+    //  ContactComponent result = CdaFhirUtilities.getGuardianContact(contacts);
+    //  assertEquals(guardianContact, result);
   }
 
   @Test

--- a/src/test/java/com/drajer/cdafromr4/CdaFhirUtilitiesTest.java
+++ b/src/test/java/com/drajer/cdafromr4/CdaFhirUtilitiesTest.java
@@ -395,8 +395,8 @@ public class CdaFhirUtilitiesTest extends BaseGeneratorTest {
     relationship.addCoding(coding);
     guardianContact.setRelationship(Collections.singletonList(relationship));
     contacts.add(guardianContact);
-    //  ContactComponent result = CdaFhirUtilities.getGuardianContact(contacts);
-    //  assertEquals(guardianContact, result);
+    List<ContactComponent> result = CdaFhirUtilities.getGuardianContacts(contacts);
+    assertEquals(1, result.size());
   }
 
   @Test

--- a/src/test/resources/CdaTestData/Cda/Medication/Medication.xml
+++ b/src/test/resources/CdaTestData/Cda/Medication/Medication.xml
@@ -124,6 +124,9 @@
                 <statusCode code="completed"/>
                 <effectiveTime xsi:type="IVL_TS"><low value="20201023"/>
                 </effectiveTime>
+                <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                    <period nullFlavor="UNK"/>
+                </effectiveTime>
                 <doseQuantity nullFlavor="NI"/>
                 <consumable>
                     <manufacturedProduct classCode="MANU">
@@ -146,6 +149,9 @@
                 <effectiveTime xsi:type="IVL_TS"><low nullFlavor="NI"/>
                     <high nullFlavor="NI"/>
                 </effectiveTime>
+                <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                    <period nullFlavor="UNK"/>
+                </effectiveTime>
                 <doseQuantity nullFlavor="NI"/>
                 <consumable>
                     <manufacturedProduct classCode="MANU">
@@ -167,6 +173,9 @@
                 <statusCode code="active"/>
                 <effectiveTime xsi:type="IVL_TS"><low value="20201015143000+0100"/>
                     <high nullFlavor="NI"/>
+                </effectiveTime>
+                <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                    <period nullFlavor="UNK"/>
                 </effectiveTime>
                 <doseQuantity value="500" unit="mg"/>
                 <consumable>

--- a/src/test/resources/CdaTestData/Cda/Medication/MedicationAdminR31.xml
+++ b/src/test/resources/CdaTestData/Cda/Medication/MedicationAdminR31.xml
@@ -59,6 +59,10 @@
                 <effectiveTime xsi:type="IVL_TS"><low value="20231227000000+0000"/>
                     <high nullFlavor="NI"/>
                 </effectiveTime>
+                <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                    <period nullFlavor="UNK"/>
+                </effectiveTime>
+                <routeCode code="47625008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Intravenous route (qualifier value)"></routeCode>
                 <doseQuantity value="500" unit="mg"/>
                 <consumable>
                     <manufacturedProduct classCode="MANU">
@@ -80,6 +84,10 @@
                 <effectiveTime xsi:type="IVL_TS"><low value="20231227000000+0000"/>
                     <high nullFlavor="NI"/>
                 </effectiveTime>
+                <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                    <period nullFlavor="UNK"/>
+                </effectiveTime>
+                <routeCode code="47625008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Intravenous route (qualifier value)"></routeCode>
                 <doseQuantity value="500" unit="mg"/>
                 <consumable>
                     <manufacturedProduct classCode="MANU">
@@ -101,6 +109,10 @@
                 <effectiveTime xsi:type="IVL_TS"><low value="20231227000000+0000"/>
                     <high nullFlavor="NI"/>
                 </effectiveTime>
+                <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                    <period nullFlavor="UNK"/>
+                </effectiveTime>
+                <routeCode code="47625008" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED-CT" displayName="Intravenous route (qualifier value)"></routeCode>
                 <doseQuantity value="500" unit="mg"/>
                 <consumable>
                     <manufacturedProduct classCode="MANU">

--- a/src/test/resources/CdaTestData/Cda/Medication/MedicationR31.xml
+++ b/src/test/resources/CdaTestData/Cda/Medication/MedicationR31.xml
@@ -47,6 +47,9 @@
                 <statusCode code="active"/>
                 <effectiveTime xsi:type="IVL_TS"><low value="20231227000000+0000"/>
                 </effectiveTime>
+                <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                    <period nullFlavor="UNK"/>
+                </effectiveTime>
                 <doseQuantity value="1" unit="TAB"/>
                 <consumable>
                     <manufacturedProduct classCode="MANU">
@@ -66,6 +69,9 @@
                 <id root="2.16.840.1.113883.1.1.1.1" extension="b6bd7100-48af-4c69-a557-c13235f72f74"/>
                 <statusCode code="active"/>
                 <effectiveTime xsi:type="IVL_TS"><low value="20231227000000+0000"/>
+                </effectiveTime>
+                <effectiveTime xsi:type="PIVL_TS" institutionSpecified="true" operator="A">
+                    <period nullFlavor="UNK"/>
                 </effectiveTime>
                 <doseQuantity value="1" unit="TAB"/>
                 <consumable>


### PR DESCRIPTION
Release 3.1.11: Resolved issues and enhancements

- Fixed warnings in Administered Medication schema for effectiveTime and dropped Medication Requests (#932)
- Added support for routeCode in Medication when dosage.route.coding is present (ECR 1.1)
- Resolved issue where only first guardian was added to EICR and added support for Emergency Contact coded with nullFlavour and coded translation code (#929)
- Fixed discrepancy between US Core 6.1.0 and EICR 3.1.1 Tribal Affiliation requirements and value type (#923)
- Addressed missing Occupational Hazard causing validation errors in version 3.1.9 (#918)
- Resolved issue with missing resultObservation-author and resultOrganizer-author in eICR (#921)
- Fixed inconsistent Spring property management support


