### PR TITLE
docker-compose.yml fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,10 +32,10 @@ services:
       - custom-query.directory=/config/custom-queries
       - jdbc.url=jdbc:postgresql://postgres_container:5432/ecrNow
       - jdbc.username=postgres
-      - jdbc.password=ecr@2024
+      - jdbc.password=ecrnow@2024
       - security.key=test123
     ports:
-      - "8081:8080"
+      - "8081:8081"
 
 networks:
   ecrnow_network:


### PR DESCRIPTION
Hi there - I recently attempted to run this application from scratch following your configuration guide. There were two things in the `docker-compose.yml` that did not work out of the box:

1. The password set in the `postgres` service does not match the one set in the `ecr-now` service's configuration
2. The port mappings for the `ecr-now` service did not line up with the port that the app actually runs on inside the container (for me, it runs on port 8081 so the mapping only works as `8081:8081`)
  - This one I am less confident in, as it could be something related to my specific docker setup. Feel free to ignore if you do not believe this to be an issue for anyone else

I am raising this PR primarily for transparency, and so that others like myself do not waste any time trying to troubleshoot these things - feel free to close it and fix these issues yourselves if you prefer to do it that way. Thanks!