### PR TITLE
Fix case-sensitive matching of Message-ID header in Direct messages

### DIFF
--- a/src/main/java/com/drajer/bsa/routing/impl/DirectTransportImpl.java
+++ b/src/main/java/com/drajer/bsa/routing/impl/DirectTransportImpl.java
@@ -276,7 +276,7 @@ public class DirectTransportImpl implements DataTransportInterface {
       headers = m.getAllHeaders();
       while (headers.hasMoreElements()) {
         Header h = (Header) headers.nextElement();
-        if (h.getName().contains("Message-ID")) {
+        if (h.getName().toLowerCase().contains("message-id")) {
           return h.getValue();
         }
       }

--- a/src/main/java/com/drajer/routing/impl/DirectResponseReceiver.java
+++ b/src/main/java/com/drajer/routing/impl/DirectResponseReceiver.java
@@ -103,7 +103,7 @@ public class DirectResponseReceiver extends RRReceiver {
 
         while (headers.hasMoreElements()) {
           Header h = (Header) headers.nextElement();
-          if (h.getName().contains("Message-ID")) {
+          if (h.getName().toLowerCase().contains("message-id")) {
             mId = h.getValue();
             logger.info("Message-ID: {}", mId);
           }


### PR DESCRIPTION
- The "Message-ID" header extraction in DirectTransportImpl and DirectResponseReceiver used a case-sensitive contains "Message-ID" check, which would miss the header if a mail server returned it with different casing (e.g., "Message-Id", "message-id").
- Changed to case-insensitive comparison toLowerCase().contains("message-id") to align with RFC 5322 / RFC 2822, which state header field names are case-insensitive.