### PR TITLE
fix: medication table column order

### DIFF
--- a/src/main/java/com/drajer/cdafromr4/CdaMedicationGenerator.java
+++ b/src/main/java/com/drajer/cdafromr4/CdaMedicationGenerator.java
@@ -5,7 +5,6 @@ import com.drajer.cda.utils.CdaGeneratorUtils;
 import com.drajer.sof.model.LaunchDetails;
 import com.drajer.sof.model.R4FhirData;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -1177,7 +1176,7 @@ public class CdaMedicationGenerator {
 
         String medicationDosagePeriodText = dosageText + CdaGeneratorConstants.PIPE + periodText;
 
-        Map<String, String> bodyvals = new HashMap<>();
+        Map<String, String> bodyvals = new LinkedHashMap<>();
         bodyvals.put(CdaGeneratorConstants.MED_TABLE_COL_1_BODY_CONTENT, medDisplayName);
         bodyvals.put(CdaGeneratorConstants.MED_TABLE_COL_2_BODY_CONTENT, dt);
         bodyvals.put(
@@ -1341,7 +1340,7 @@ public class CdaMedicationGenerator {
                 + CdaGeneratorConstants.PIPE
                 + periodText;
 
-        Map<String, String> bodyvals = new HashMap<>();
+        Map<String, String> bodyvals = new LinkedHashMap<>();
         bodyvals.put(CdaGeneratorConstants.MED_COL_1_BODY_CONTENT, medDisplayName);
         bodyvals.put(CdaGeneratorConstants.MED_COL_2_BODY_CONTENT, dt);
         bodyvals.put(CdaGeneratorConstants.MED_COL_3_BODY_CONTENT, medicationDosagePeriodText);
@@ -1447,7 +1446,7 @@ public class CdaMedicationGenerator {
         String medicationDosagePeriodText =
             CdaFhirUtilities.getStringForQuantity(dose) + CdaGeneratorConstants.PIPE + periodText;
 
-        Map<String, String> bodyvals = new HashMap<>();
+        Map<String, String> bodyvals = new LinkedHashMap<>();
         bodyvals.put(CdaGeneratorConstants.MED_COL_1_BODY_CONTENT, medDisplayName);
         bodyvals.put(CdaGeneratorConstants.MED_COL_2_BODY_CONTENT, dt);
         bodyvals.put(CdaGeneratorConstants.MED_COL_3_BODY_CONTENT, medicationDosagePeriodText);

--- a/src/test/resources/CdaTestData/Cda/Medication/MedicationAdminR31.xml
+++ b/src/test/resources/CdaTestData/Cda/Medication/MedicationAdminR31.xml
@@ -16,35 +16,35 @@
                 <tbody>
                     <tr>
                         <td>
-                            <content ID="medicationDosagePeriod1">500|http://unitsofmeasure.org|mg|Unknown</content>
-                        </td>
-                        <td>
                             <content ID="medication1">NDA020800 0.3 ML Epinephrine 1 MG/ML Auto-Injecto</content>
                         </td>
                         <td>
                             <content ID="medicationDate1">20231227000000+0000</content>
                         </td>
+                        <td>
+                            <content ID="medicationDosagePeriod1">500|http://unitsofmeasure.org|mg|Unknown</content>
+                        </td>
                     </tr>
                     <tr>
-                        <td>
-                            <content ID="medicationDosagePeriod2">500|http://unitsofmeasure.org|mg|Unknown</content>
-                        </td>
                         <td>
                             <content ID="medication2">NDA020800 0.3 ML Epinephrine 1 MG/ML Auto-Injecto</content>
                         </td>
                         <td>
                             <content ID="medicationDate2">20231227000000+0000</content>
                         </td>
+                        <td>
+                            <content ID="medicationDosagePeriod2">500|http://unitsofmeasure.org|mg|Unknown</content>
+                        </td>
                     </tr>
                     <tr>
-                        <td>
-                            <content ID="medicationDosagePeriod3">500|http://unitsofmeasure.org|mg|Unknown</content>
-                        </td>
                         <td>
                             <content ID="medication3">NDA020800 0.3 ML Epinephrine 1 MG/ML Auto-Injecto</content>
                         </td>
                         <td>
                             <content ID="medicationDate3">20231227000000+0000</content>
+                        </td>
+                        <td>
+                            <content ID="medicationDosagePeriod3">500|http://unitsofmeasure.org|mg|Unknown</content>
                         </td>
                     </tr>
                 </tbody>

--- a/src/test/resources/CdaTestData/Cda/Medication/MedicationR31.xml
+++ b/src/test/resources/CdaTestData/Cda/Medication/MedicationR31.xml
@@ -16,35 +16,35 @@
                 <tbody>
                     <tr>
                         <td>
-                            <content ID="medDosagePeriod1">1|http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm|TAB|frequency: 2|period: 1|periodUnit: D</content>
+                            <content ID="med1">Prednisone 5 MG Oral Tablet [Deltasone]</content>
                         </td>
                         <td>
                             <content ID="medDate1">20231227000000+0000</content>
                         </td>
                         <td>
-                            <content ID="med1">Prednisone 5 MG Oral Tablet [Deltasone]</content>
+                            <content ID="medDosagePeriod1">1|http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm|TAB|frequency: 2|period: 1|periodUnit: D</content>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <content ID="medDosagePeriod2">1|http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm|TAB|Unknown</content>
+                            <content ID="med2">NDA020800 0.3 ML Epinephrine 1 MG/ML Auto-Injector</content>
                         </td>
                         <td>
                             <content ID="medDate2">20231227000000+0000</content>
                         </td>
                         <td>
-                            <content ID="med2">NDA020800 0.3 ML Epinephrine 1 MG/ML Auto-Injector</content>
+                            <content ID="medDosagePeriod2">1|http://terminology.hl7.org/CodeSystem/v3-orderableDrugForm|TAB|Unknown</content>
                         </td>
                     </tr>
                     <tr>
                         <td>
-                            <content ID="medDosagePeriod3">1|http://unitsofmeasure.org|{tbl}|frequency: 2|period: 6|periodUnit: H</content>
+                            <content ID="med3">8 HR Carbidopa 36.25 MG / L-DOPA 145 MG Extended Release Oral Capsule [Rytary]</content>
                         </td>
                         <td>
                             <content ID="medDate3">20241227000000+0000</content>
                         </td>
                         <td>
-                            <content ID="med3">8 HR Carbidopa 36.25 MG / L-DOPA 145 MG Extended Release Oral Capsule [Rytary]</content>
+                            <content ID="medDosagePeriod3">1|http://unitsofmeasure.org|{tbl}|frequency: 2|period: 6|periodUnit: H</content>
                         </td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
Medication table body column ordering by using LinkedHashMap for medication row values before rendering <tbody> cells. This ensures body cells are emitted in the same order as the table headers: medication name, start date, then dosage and period.