### PR TITLE
fix: correct swapped column names

### DIFF
--- a/src/main/java/com/drajer/cda/utils/CdaGeneratorConstants.java
+++ b/src/main/java/com/drajer/cda/utils/CdaGeneratorConstants.java
@@ -1144,16 +1144,16 @@ public class CdaGeneratorConstants {
   // Inner table headers
   public static final String INNER_COL_TEST = "Test";
   public static final String INNER_COL_OUTCOME = "Outcome";
-  public static final String INNER_COL_INTERP = "Interpretation";
   public static final String INNER_COL_DATE = "Date(s)";
+  public static final String INNER_COL_INTERP = "Interpretation";
   public static final String INNER_COL_REF_RANGE = "Reference Range";
   public static final String INNER_COL_COLLECTION = "Specimen Collection Date";
 
   // Inner table content IDs
   public static final String INNER_BODY_TEST = "test";
   public static final String INNER_BODY_OUTCOME = "outcome";
-  public static final String INNER_BODY_INTERP = "interpretation";
   public static final String INNER_BODY_DATE = "date";
+  public static final String INNER_BODY_INTERP = "interpretation";
   public static final String INNER_BODY_REF_RANGE = "refRange";
   public static final String INNER_BODY_COLLECTION = "collection";
 

--- a/src/main/java/com/drajer/cdafromr4/CdaResultGenerator.java
+++ b/src/main/java/com/drajer/cdafromr4/CdaResultGenerator.java
@@ -1532,7 +1532,7 @@ public class CdaResultGenerator {
    * <p><tr> <td colspan="20"> <list styleCode="none"><item>
    *
    * <table>
-   *         <thead> Test | Outcome | Interpretation | Date(s) | Reference Range | Specimen Collection Date </thead>
+   *         <thead> Test | Outcome | Date(s) | Interpretation | Reference Range | Specimen Collection Date </thead>
    *         <tbody> one <tr> per component </tbody>
    *       </table>
    *
@@ -1576,11 +1576,11 @@ public class CdaResultGenerator {
     sb.append(
         CdaGeneratorUtils.getXmlForText(
             CdaGeneratorConstants.TABLE_HEAD_CONTENT_EL_NAME,
-            CdaGeneratorConstants.INNER_COL_INTERP));
+            CdaGeneratorConstants.INNER_COL_DATE));
     sb.append(
         CdaGeneratorUtils.getXmlForText(
             CdaGeneratorConstants.TABLE_HEAD_CONTENT_EL_NAME,
-            CdaGeneratorConstants.INNER_COL_DATE));
+            CdaGeneratorConstants.INNER_COL_INTERP));
     sb.append(
         CdaGeneratorUtils.getXmlForText(
             CdaGeneratorConstants.TABLE_HEAD_CONTENT_EL_NAME,

--- a/src/test/resources/CdaTestData/Cda/Result/Result.xml
+++ b/src/test/resources/CdaTestData/Cda/Result/Result.xml
@@ -28,8 +28,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -86,8 +86,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -144,8 +144,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -202,8 +202,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -260,8 +260,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -318,8 +318,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -376,8 +376,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -434,8 +434,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -492,8 +492,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -550,8 +550,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -608,8 +608,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -666,8 +666,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -724,8 +724,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -782,8 +782,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -840,8 +840,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -898,8 +898,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -956,8 +956,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -1014,8 +1014,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -1072,8 +1072,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -1130,8 +1130,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -1188,8 +1188,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>

--- a/src/test/resources/CdaTestData/Cda/Result/result-section-trigger.xml
+++ b/src/test/resources/CdaTestData/Cda/Result/result-section-trigger.xml
@@ -28,8 +28,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -86,8 +86,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -144,8 +144,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -202,8 +202,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>
@@ -260,8 +260,8 @@
                                             <tr>
                                                 <th>Test</th>
                                                 <th>Outcome</th>
-                                                <th>Interpretation</th>
                                                 <th>Date(s)</th>
+                                                <th>Interpretation</th>
                                                 <th>Reference Range</th>
                                                 <th>Specimen Collection Date</th>
                                             </tr>


### PR DESCRIPTION
Hi Team,
Corrected the column names to match the corresponding data: Dates and Interpretation.
Thanks.