### PR TITLE
Ecr cql performance fixes

### DIFF
--- a/src/main/java/com/drajer/cdafromr4/CdaHeaderGenerator.java
+++ b/src/main/java/com/drajer/cdafromr4/CdaHeaderGenerator.java
@@ -42,7 +42,7 @@ public class CdaHeaderGenerator {
   private static final Properties properties = new Properties();
   private static final Logger logger = LoggerFactory.getLogger(CdaHeaderGenerator.class);
 
-  private static final String SW_APP_VERSION = "4.0.3";
+  private static final String SW_APP_VERSION = "4.0.4";
   private static String SW_APP_NAME = "ecrNowApp";
   private static final String SPRING_PROFILES_ACTIVE = "spring.profiles.active";
   private static final String DEFAULT_PROPERTIES_FILE = "application.properties";

--- a/src/main/java/com/drajer/ecrapp/config/SpringConfiguration.java
+++ b/src/main/java/com/drajer/ecrapp/config/SpringConfiguration.java
@@ -87,7 +87,6 @@ public class SpringConfiguration {
     this.fhirRetryTemplateConfig = fhirRetryTemplateConfig;
   }
 
-
   @Bean
   @Primary
   FederatedRepository getEcrRepository(InMemoryFhirRepository artifactRepository) {

--- a/src/main/java/com/drajer/ecrapp/config/SpringConfiguration.java
+++ b/src/main/java/com/drajer/ecrapp/config/SpringConfiguration.java
@@ -87,11 +87,11 @@ public class SpringConfiguration {
     this.fhirRetryTemplateConfig = fhirRetryTemplateConfig;
   }
 
+
   @Bean
   @Primary
-  FederatedRepository getEcrRepository(
-      InMemoryFhirRepository artifactRepository, RestRepository ehrRepository) {
-    return new FederatedRepository(artifactRepository, ehrRepository);
+  FederatedRepository getEcrRepository(InMemoryFhirRepository artifactRepository) {
+    return new FederatedRepository(artifactRepository);
   }
 
   @Bean


### PR DESCRIPTION

We implemented the same fix discussed with Patrick, without adding any caching. We removed the ECR repository from the directory repository, so CQL evaluation now uses only the in-memory repository.
After this change, processing time has improved from ~5–6 minutes to ~1 minute, which is almost equivalent to the performance without caching — around 5x improvement.